### PR TITLE
Fixed None type with neighbors and rel_mask bug in covolve.

### DIFF
--- a/se3cnn/point_utils.py
+++ b/se3cnn/point_utils.py
@@ -17,8 +17,8 @@ def convolve(kernel, features, geometry, neighbors=None, rel_mask=None):
     if not has_batch:
         features = features.unsqueeze(0)
         geometry = geometry.unsqueeze(0)
-        neighbors = neighbors.unsqueeze(0)
-        rel_mask = rel_mask.unsqueeze(0)
+        neighbors = neighbors.unsqueeze(0) if neighbors is not None else None
+        rel_mask = rel_mask.unsqueeze(0) if rel_mask is not None else None
 
     if neighbors is None:
         diff_matrix = difference_matrix(geometry)  # [batch, point_out, point_in, 3]


### PR DESCRIPTION
Before the change, this function would raise an error when ```has_batch == false``` and no neighbors or rel_mask was supplied.