### PR TITLE
PeriodicConvolution memory consumption & SO3.xyz_to_angles nan

### DIFF
--- a/examples/point/structure.py
+++ b/examples/point/structure.py
@@ -60,6 +60,7 @@ class Network(torch.nn.Module):
 
 def main():
     import time
+    torch.manual_seed(42)
     random.seed(42)
     torch.set_default_dtype(torch.float64)
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
@@ -90,7 +91,7 @@ def main():
             # print("step={} loss={:.2e} {}".format(step, loss.item(), success[-10:]))
     
     t2 = time.time()
-    print(t2-t1)
+    print(f"Training time: {t2-t1:.2f} seconds")
 
     def test(filename):
         structures, labels = get_dataset(filename)

--- a/examples/point/structure.py
+++ b/examples/point/structure.py
@@ -59,6 +59,8 @@ class Network(torch.nn.Module):
 
 
 def main():
+    import time
+    random.seed(42)
     torch.set_default_dtype(torch.float64)
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
 
@@ -71,6 +73,7 @@ def main():
     optimizer = torch.optim.Adam(f.parameters())
     success = []
 
+    t1 = time.time()
     for step in range(800):
         i = random.randint(0, len(structures) - 1)
         struct = structures[i]
@@ -84,8 +87,10 @@ def main():
         if step % 2 == 0:
             optimizer.step()
             optimizer.zero_grad()
-
-            print("step={} loss={:.2e} {}".format(step, loss.item(), success[-10:]))
+            # print("step={} loss={:.2e} {}".format(step, loss.item(), success[-10:]))
+    
+    t2 = time.time()
+    print(t2-t1)
 
     def test(filename):
         structures, labels = get_dataset(filename)
@@ -93,8 +98,9 @@ def main():
         from sklearn.metrics import confusion_matrix
         print(confusion_matrix(labels, pred))
 
-    test('structure-1atomstype-trainset.json')
-    test('structure-1atomstype-testset.json')
+    with torch.no_grad():
+        test('structure-1atomstype-trainset.json')
+        test('structure-1atomstype-testset.json')
 
 
 if __name__ == '__main__':

--- a/se3cnn/SO3.py
+++ b/se3cnn/SO3.py
@@ -83,7 +83,10 @@ def xyz_to_angles(x, y=None, z=None):
             z = torch.tensor(z, dtype=torch.get_default_dtype())
         x = torch.stack([x, y, z], dim=-1)
 
-    x = x / torch.norm(x, 2, -1, keepdim=True)
+    x = torch.nn.functional.normalize(x, p=2, dim=-1)  # forward 0's instead of nan for zero-radius
+    x.masked_fill_(x < -1., -1.)                       # mitigate numerical inaccuracies from normalization
+    x.masked_fill_(x > 1., 1.)
+
     beta = torch.acos(x[..., 2])
     alpha = torch.atan2(x[..., 1], x[..., 0])
     return alpha, beta


### PR DESCRIPTION
1. **SO3.xyz_to_angles** produced nan values in cases where normalization due to floating point error leaded to input values > 1 or < -1 in acos function. 
Now it explicitly bounded to the range after normalization.

2. **PeriodicConvolution**: changed implementation of output tensor calculations from "kernels". 
Peak memory consumption drops from quadratic to **linear** (in number of points) on **inference**.
Inference for C240 capped now at ~1.2 GB.
Also, should make training in structure.py about 10% faster. 

PeriodicConvolution **caveats**: 
1. In structure.py inference mode (in sense of not retaining buffer of computation graph) comes with torch.no_grad(). Memory consumption **on training** is still **quadratic**.
2. Prior version runs out of memory on CUDA (6 GB) for C240, even with torch.no_grad()