### PR TITLE
Dataset class with preprocesing for crystals; and Periodic Convolution with custom backward

### DIFF
--- a/examples/point/structure.py
+++ b/examples/point/structure.py
@@ -37,7 +37,7 @@ class Network(torch.nn.Module):
 
         R = partial(CosineBasisModel, max_radius=3.8, number_of_basis=10, h=100, L=2, act=relu)
         K = partial(Kernel, RadialModel=R)
-        C = partial(PeriodicConvolution, K)
+        C = partial(PeriodicConvolution, Kernel=K, max_radius=3.8)
 
         self.firstlayers = torch.nn.ModuleList([
             GatedBlock(Rs_in, Rs_out, relu, sigmoid, C)
@@ -53,7 +53,7 @@ class Network(torch.nn.Module):
 
         for i, m in enumerate(self.firstlayers):
             assert torch.isfinite(features).all(), i
-            features = m(features.div(4 ** 0.5), geometry, structure.lattice, 3.8)
+            features = m(features.div(4 ** 0.5), geometry, structure.lattice)
 
         return self.lastlayers(features).squeeze(0)
 

--- a/se3cnn/point/operations.py
+++ b/se3cnn/point/operations.py
@@ -139,16 +139,16 @@ class NeighborsConvolution(torch.nn.Module):
 
 
 class PeriodicConvolution(torch.nn.Module):
-    def __init__(self, Kernel, Rs_in, Rs_out):
+    def __init__(self, Rs_in, Rs_out, Kernel, max_radius):
         super().__init__()
+        self.max_radius = max_radius
         self.kernel = Kernel(Rs_in, Rs_out)
 
-    def forward(self, features, geometry, lattice, max_radius, n_norm=None):
+    def forward(self, features, geometry, lattice, n_norm=None):
         """
         :param features:   tensor [batch, point, channel]
         :param geometry:   tensor [batch, point, xyz]
         :param lattice:    pymatgen.Lattice
-        :param max_radius: float
         :param n_norm:     float
         :return:           tensor [batch, point, channel]
         """
@@ -169,7 +169,7 @@ class PeriodicConvolution(torch.nn.Module):
             radius_list = []
 
             for a, site_a in enumerate(structure):
-                nei = structure.get_sites_in_sphere(site_a.coords, max_radius, include_index=True, include_image=True)
+                nei = structure.get_sites_in_sphere(site_a.coords, self.max_radius, include_index=True, include_image=True)
                 if nei:
                     bs_entry = torch.tensor([entry[2] for entry in nei], dtype=torch.long, device=features.device)   # [r_part_a]
                     bs_list.append(bs_entry)

--- a/se3cnn/point/operations.py
+++ b/se3cnn/point/operations.py
@@ -197,3 +197,79 @@ class PeriodicConvolution(torch.nn.Module):
             out.div_(n_norm ** 0.5)
 
         return out                                                                                                   # [batch, point, channel]
+
+
+class PeriodicConvolutionPrep(torch.nn.Module):
+    def __init__(self, Rs_in, Rs_out, Kernel):
+        super().__init__()
+        self.kernel = Kernel(Rs_in, Rs_out)
+
+    def forward(self, features, radii, bs_slice):
+        """
+        :param features: [point, channel_in]
+        :param radii: [r, xyz]
+        :param bs_slice:
+        :return: out: [point, channel_out]
+        """
+        kernels = self.kernel(radii)                                                                # [r, i, j]
+        out = PeriodicConvolutionFunc.apply(kernels, bs_slice, features)
+        return out
+
+
+class PeriodicConvolutionFunc(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, kernels, bs_slice, features):
+        ctx.save_for_backward(kernels, bs_slice, features)                                          # save input for backward pass
+
+        points_num = features.size(0)
+        in_channels, out_channels = kernels.size(2), kernels.size(1)
+
+        features = features.view(points_num * in_channels)                                          # [b*j]
+        bs_slice = bs_slice.long()
+
+        out = features.new_zeros(points_num, out_channels)                                          # [a, i]
+        ks_start = 0                                                                                # kernels stacked flat - indicate where block of interest begins
+        for a, bs in enumerate(bs_slice):
+            bs = bs[1:1+bs[0]]
+            k_b = features.new_zeros(points_num, out_channels, in_channels)                         # [b, i, j]
+            k_b.index_add_(dim=0, index=bs, source=kernels[ks_start:ks_start + bs.size(0)])
+            ks_start += bs.size(0)
+            k_b = k_b.transpose(0, 1).contiguous().view(out_channels, points_num * in_channels)     # [i, b*j]
+
+            out[a] = torch.mv(k_b, features)                                                        # [i, b*j] @ [b*j] -> [i]
+
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        kernels, bs_slice, features = ctx.saved_tensors                                             # restore input from context
+        del ctx                                                                                     # pros: allows to decrease peak memory usage (del kernels); cons: backward cannot be called more than once!
+
+        points_num, out_channels = grad_output.size(0), grad_output.size(1)
+        in_channels = features.size(1)
+
+        bs_slice = bs_slice.long()
+
+        # region features_grad[b, j] = sum_(a, i){ k_b[a, b, i, j] * grad_output[a, i] }
+        features_grad = torch.zeros_like(features).view(points_num * in_channels)
+        ks_start = 0
+        for a, bs in enumerate(bs_slice):
+            bs = bs[1:1+bs[0]]
+            k_b = features.new_zeros(points_num, out_channels, in_channels)
+            k_b.index_add_(dim=0, index=bs, source=kernels[ks_start:ks_start + bs.size(0)])
+            ks_start += bs.size(0)
+            k_b = k_b.transpose(0, 1).contiguous().view(out_channels, points_num * in_channels)
+
+            features_grad += (k_b * grad_output[a].unsqueeze(1).expand_as(k_b)).sum(dim=0)
+
+        features_grad = features_grad.view(points_num, in_channels)
+        # endregion
+
+        del kernels
+
+        # region kernels_grad[r, i, j] = features[fb(r), j] * grad_output[fa(r), i].  Each r correspond to unique pair (a, b)
+        fa, fb = torch.tensor([(a, b.item()) for a, bs in enumerate(bs_slice) for b in bs[1:1+bs[0]]], dtype=torch.long, device=features.device).t()
+        kernels_grad = features[fb].unsqueeze(1) * grad_output[fa].unsqueeze(2)                     # implicit broadcasting: [r, 1, j] and [r, i, 1] -> [r, i ,j]
+        # endregion
+
+        return kernels_grad, None, features_grad                                                    # No gradients for bs_slice

--- a/se3cnn/util/dataset/crystals.py
+++ b/se3cnn/util/dataset/crystals.py
@@ -2,9 +2,13 @@ from os.path import join, isfile, isdir
 from os import mkdir
 from shutil import rmtree
 
-import numpy as np
 import torch
 from torch.utils.data import Dataset
+
+import numpy as np
+import pymatgen
+
+from tqdm import tqdm
 
 
 class CrystalCIF(Dataset):
@@ -15,84 +19,140 @@ class CrystalCIF(Dataset):
     |_______property0.pth
     |_______property1.pth
     |_______cif
-    |        |____0.cif
-    |        |____1.cif
+    |        |____name0.cif
+    |        |____name1.cif
     |
-    |_______preprocessed
-             |____site_a_coord.pth
+    |_______preprocessed (script creates this folder and its contents)
+             |____geometries.pth
              |____atomic_charges.pth
              |____lattice_params.pth
              |____max_radius_{max_radius_value}
-                    |_____radius.pth
+                    |_____radii.pth
                     |_____bs.pth
-                    |_____partitioning.pth
+                    |_____partitions.pth
     """
     def __init__(self, root, max_radius, material_properties=None):
         """
         :param root: string path to the root directory of dataset
+        :param max_radius: float radius of sphere (?)
         :param material_properties: (optional) list of file paths containing additional properties, one type of property per file
         """
-        preprocessed_dir = join(root, 'preprocessed')                                           # check if (all) basic preprocessed data is available, if it is not - compute
-        if not isdir(preprocessed_dir):
-            CrystalCIF.preprocess_base(root)
-        elif (
-                not isfile(join(preprocessed_dir, 'site_a_coord.pth'))
-                or not isfile(join(preprocessed_dir, 'atomic_charges.pth'))
-                or not isfile(join(preprocessed_dir, 'lattice_params.pth'))
-                or not isfile(join(preprocessed_dir, 'partitioning.pth'))
-        ):
-            rmtree(preprocessed_dir)                                                            # clean up corrupted structure
-            CrystalCIF.preprocess_base(root)
-        else:
-            pass
+        preprocessed_dir = join(root, 'preprocessed')
+        preprocessed_radius_dir = join(preprocessed_dir, f'max_radius_{max_radius}')
 
-        preprocessed_radius_dir = join(preprocessed_dir, f'max_radius_{max_radius}')            # check if data for requested max_radius is available, if it is not - compute
-        if not isdir(preprocessed_radius_dir):
-            CrystalCIF.preprocess_radius(preprocessed_dir, max_radius)
-        elif (
-                not isfile(join(preprocessed_radius_dir, 'radius.pth'))
-                or not isfile(join(preprocessed_radius_dir, 'bs.pth'))
-                or not isfile(join(preprocessed_radius_dir, 'partitioning.pth'))
+        if (
+                isdir(preprocessed_radius_dir)
+                and (not isfile(join(preprocessed_radius_dir, 'radii.pth'))
+                     or not isfile(join(preprocessed_radius_dir, 'bs.pth'))
+                     or not isfile(join(preprocessed_radius_dir, 'partitions.pth')))
         ):
-            rmtree(preprocessed_radius_dir)                                                     # clean up corrupted structure
-            CrystalCIF.preprocess_radius(root, max_radius)
+            rmtree(preprocessed_radius_dir)
+            CrystalCIF.preprocess(root, max_radius)
+        elif not isdir(preprocessed_radius_dir):
+            CrystalCIF.preprocess(root, max_radius)
         else:
             pass
 
         self.names = np.load(join(root, 'names.npy'))
         self.size = len(self.names)
+        self.geometries = torch.load(join(preprocessed_dir, 'geometries.pth'))
         self.atomic_charges = torch.load(join(preprocessed_dir, 'atomic_charges.pth'))
         self.lattice_params = torch.load(join(preprocessed_dir, 'lattice_params.pth'))
 
-        self.radius = torch.load(join(preprocessed_radius_dir, 'radius.pth'))
+        self.radii = torch.load(join(preprocessed_radius_dir, 'radii.pth'))
         self.bs = torch.load(join(preprocessed_radius_dir, 'bs.pth'))
-        self.partitioning = torch.load(join(preprocessed_radius_dir, 'partitioning.pth'))
+        self.partitions = torch.load(join(preprocessed_radius_dir, 'partitions.pth'))
 
         if material_properties:
             self.properties = torch.stack([torch.load(join(root, property_path)) for property_path in material_properties], dim=1)
         else:
-            self.properties = self.radius.new_zeros(self.size, 1)                                # placeholder for consistency
+            self.properties = None
 
     def __getitem__(self, item_id):
-        start, end = self.partitioning[item_id]
-        return self.radius[start:end], self.bs[start:end], self.atomic_charges[item_id], self.lattice_params[item_id], self.properties[item_id]
+        start, end = self.partitions[item_id]
+        properties = None if self.properties is None else self.properties[item_id]
+        return self.radii[start:end], self.bs[start:end], self.geometries[item_id], self.atomic_charges[item_id], self.lattice_params[item_id], properties
 
     def __len__(self):
         return self.size
 
     @staticmethod
-    def preprocess_base(root):
+    def preprocess(root, max_radius=None):
+        # region 0. Set up
         preprocessed_dir = join(root, 'preprocessed')
-        mkdir(preprocessed_dir)
-        # TODO: complete
-        pass
+        if not isdir(preprocessed_dir):
+            mkdir(preprocessed_dir)
 
-    @staticmethod
-    def preprocess_radius(preprocessed_dir, max_radius):
-        preprocessed_radius_dir = join(preprocessed_dir, f'max_radius_{max_radius}')
-        mkdir(preprocessed_radius_dir)
-        # TODO: complete
-        pass
+        if max_radius:
+            max_radius_dir = join(preprocessed_dir, f'max_radius_{max_radius}')
+            if not isdir(max_radius_dir):
+                mkdir(max_radius_dir)
+        # endregion
 
+        # region 1. Init
+        index = np.load(join(root, 'index.npy'))
 
+        site_a_coords_list = []
+        atomic_charges_list = []
+        lattice_params_list = []
 
+        if max_radius:
+            bs_list = []
+            radii_list = []
+            partitions_list = []
+        # endregion
+
+        # region 2. Process
+        for file_rel_path in tqdm(index):
+            structure = pymatgen.Structure.from_file((join(root, 'cif', file_rel_path)))
+
+            site_a_coords_entry = torch.stack([torch.from_numpy(site.coords) for site in structure.sites])
+            atomic_charges_entry = torch.tensor([atom.number for atom in structure.species])
+
+            site_a_coords_list.append(site_a_coords_entry)
+            atomic_charges_list.append(atomic_charges_entry)
+            lattice_params_list.append(structure.lattice.abc + structure.lattice.angles)
+
+            if max_radius:
+                radii_proxy_list = []
+                bs_proxy_list = []
+                partition_start = 0
+                for site_a_coords in site_a_coords_entry:
+                    nei = structure.get_sites_in_sphere(site_a_coords.numpy(), max_radius, include_index=True)
+                    if nei:
+                        # TODO: storing bs as a list of tensors seems excessive, bitset would be nice, but python don't have one, maybe list of pointers and set of lists (?)
+                        bs_entry = torch.tensor([entry[2] for entry in nei], dtype=torch.long)      # [r_part_a]
+                        bs_proxy_list.append(bs_entry)
+
+                        site_b_coords = np.array([entry[0].coords for entry in nei])                # [r_part_a, 3]
+                        site_a_coords = np.array(site_a_coords).reshape(1, 3)                       # [1, 3]
+                        radii_proxy_list.append(site_b_coords - site_a_coords)                      # implicit broadcasting of site_a_coords
+                    else:
+                        print(f"Encountered empty nei for {file_rel_path}: {site_a_coords}")
+
+                radii_proxy = np.concatenate(radii_proxy_list)                                      # [r, 3]
+                radii_proxy[np.linalg.norm(radii_proxy, ord=2, axis=-1) < 1e-10] = 0.
+                radii_list.append(radii_proxy)
+                bs_list.append(bs_proxy_list)
+                partitions_list.append((partition_start, partition_start + radii_proxy.shape[0]))
+                partition_start += radii_proxy.shape[0]
+        # endregion
+
+        # region 3. Post-process
+        lattice_params = torch.tensor(lattice_params_list)
+
+        if max_radius:
+            radii = torch.from_numpy(np.concatenate(radii_list))
+            partitions = torch.tensor(partitions_list, dtype=torch.long)
+        # endregion
+
+        # region 4. Store
+        torch.save(site_a_coords_list, join(preprocessed_dir, 'geometries.pth'))                    # list of z tensors [a_i, 3]            - xyz
+        torch.save(atomic_charges_list, join(preprocessed_dir, 'atomic_charges.pth'))               # list of z tensors [a_i]
+        torch.save(lattice_params, join(preprocessed_dir, 'lattice_params.pth'))                    # [z, 6]                                - xyz and angles (in degrees)
+
+        if max_radius:
+            torch.save(bs_list, join(max_radius_dir, 'bs.pth'))                                     # list of z lisradii_proxy_listts of tensors [r_i]
+            torch.save(radii, join(max_radius_dir, 'radii.pth'))                                    # tensor [sum(r_i), 3]                  - xyz
+            torch.save(partitions, join(max_radius_dir, 'partitions.pth'))                          # tensor [z, 2]                         - start/end of radii slice corresponding to z
+        # endregion

--- a/se3cnn/util/dataset/crystals.py
+++ b/se3cnn/util/dataset/crystals.py
@@ -1,0 +1,98 @@
+from os.path import join, isfile, isdir
+from os import mkdir
+from shutil import rmtree
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+
+
+class CrystalCIF(Dataset):
+    """
+    root
+    |_______index.npy
+    |_______names.npy
+    |_______property0.pth
+    |_______property1.pth
+    |_______cif
+    |        |____0.cif
+    |        |____1.cif
+    |
+    |_______preprocessed
+             |____site_a_coord.pth
+             |____atomic_charges.pth
+             |____lattice_params.pth
+             |____max_radius_{max_radius_value}
+                    |_____radius.pth
+                    |_____bs.pth
+                    |_____partitioning.pth
+    """
+    def __init__(self, root, max_radius, material_properties=None):
+        """
+        :param root: string path to the root directory of dataset
+        :param material_properties: (optional) list of file paths containing additional properties, one type of property per file
+        """
+        preprocessed_dir = join(root, 'preprocessed')                                           # check if (all) basic preprocessed data is available, if it is not - compute
+        if not isdir(preprocessed_dir):
+            CrystalCIF.preprocess_base(root)
+        elif (
+                not isfile(join(preprocessed_dir, 'site_a_coord.pth'))
+                or not isfile(join(preprocessed_dir, 'atomic_charges.pth'))
+                or not isfile(join(preprocessed_dir, 'lattice_params.pth'))
+                or not isfile(join(preprocessed_dir, 'partitioning.pth'))
+        ):
+            rmtree(preprocessed_dir)                                                            # clean up corrupted structure
+            CrystalCIF.preprocess_base(root)
+        else:
+            pass
+
+        preprocessed_radius_dir = join(preprocessed_dir, f'max_radius_{max_radius}')            # check if data for requested max_radius is available, if it is not - compute
+        if not isdir(preprocessed_radius_dir):
+            CrystalCIF.preprocess_radius(preprocessed_dir, max_radius)
+        elif (
+                not isfile(join(preprocessed_radius_dir, 'radius.pth'))
+                or not isfile(join(preprocessed_radius_dir, 'bs.pth'))
+                or not isfile(join(preprocessed_radius_dir, 'partitioning.pth'))
+        ):
+            rmtree(preprocessed_radius_dir)                                                     # clean up corrupted structure
+            CrystalCIF.preprocess_radius(root, max_radius)
+        else:
+            pass
+
+        self.names = np.load(join(root, 'names.npy'))
+        self.size = len(self.names)
+        self.atomic_charges = torch.load(join(preprocessed_dir, 'atomic_charges.pth'))
+        self.lattice_params = torch.load(join(preprocessed_dir, 'lattice_params.pth'))
+
+        self.radius = torch.load(join(preprocessed_radius_dir, 'radius.pth'))
+        self.bs = torch.load(join(preprocessed_radius_dir, 'bs.pth'))
+        self.partitioning = torch.load(join(preprocessed_radius_dir, 'partitioning.pth'))
+
+        if material_properties:
+            self.properties = torch.stack([torch.load(join(root, property_path)) for property_path in material_properties], dim=1)
+        else:
+            self.properties = self.radius.new_zeros(self.size, 1)                                # placeholder for consistency
+
+    def __getitem__(self, item_id):
+        start, end = self.partitioning[item_id]
+        return self.radius[start:end], self.bs[start:end], self.atomic_charges[item_id], self.lattice_params[item_id], self.properties[item_id]
+
+    def __len__(self):
+        return self.size
+
+    @staticmethod
+    def preprocess_base(root):
+        preprocessed_dir = join(root, 'preprocessed')
+        mkdir(preprocessed_dir)
+        # TODO: complete
+        pass
+
+    @staticmethod
+    def preprocess_radius(preprocessed_dir, max_radius):
+        preprocessed_radius_dir = join(preprocessed_dir, f'max_radius_{max_radius}')
+        mkdir(preprocessed_radius_dir)
+        # TODO: complete
+        pass
+
+
+

--- a/se3cnn/util/dataset/crystals.py
+++ b/se3cnn/util/dataset/crystals.py
@@ -72,8 +72,7 @@ class CrystalCIF(Dataset):
     def __getitem__(self, item_id):
         properties = None if self.properties is None else self.properties[item_id]
         radii_start, radii_end, bs_start, bs_end = self.partitions[item_id]
-        bs = [b[1:1+b[0]].long() for b in self.bs[bs_start:bs_end]]                                 # retrieve actual bs from slice
-        return self.radii[radii_start:radii_end], bs, self.geometries[item_id], self.atomic_charges[item_id], self.lattice_params[item_id], properties
+        return self.names[item_id], self.radii[radii_start:radii_end], self.bs[bs_start:bs_end], self.geometries[item_id], self.atomic_charges[item_id], self.lattice_params[item_id], properties
 
     def __len__(self):
         return self.size


### PR DESCRIPTION
1. CrystalCIF
Construct a dataset object from collection of .cif files. 
Gather basic characteristics in compact form and precompute radii, bs for requested max_radius. 

2. PeriodicConvolutionPrep
Having preprocessed radii and bs allows to simplify routine, but most importantly, knowing all bs beforehand allows to have equally simple custom backward pass (peak memory is linear in number of atoms in structure). 
Support of repeated backward (e.g: higher order derivatives) is traded for another constant factor improvement in memory consumption.
Combined, for network architecture as in strucutre.py, with PeriodicConvolutionPrep blocks, training on structure of 440 atoms fits in 5GB on GPU.  