### PR TITLE
Real spherical harmonics: L<=6 (cuda)

### DIFF
--- a/se3cnn/SO3.py
+++ b/se3cnn/SO3.py
@@ -290,7 +290,6 @@ def spherical_harmonics(order, alpha, beta, sph_last=False, dtype=None, device=N
 
 def spherical_harmonics_xyz(order, xyz, sph_last=False, dtype=None, device=None):
     """
-
     spherical harmonics
 
     :param order: int or list
@@ -319,10 +318,10 @@ def spherical_harmonics_xyz(order, xyz, sph_last=False, dtype=None, device=None)
     with torch_default_dtype(torch.float64):
         if device.type == 'cuda' and max(order) <= 6:
             max_l = max(order)
-            out = xyz.new_empty(((max_l + 1)*(max_l + 1), xyz.size(0)))                                 # [filters, batch_size]
+            out = xyz.new_empty(((max_l + 1)*(max_l + 1), xyz.size(0)))                                    # [filters, batch_size]
             xyz_unit = torch.nn.functional.normalize(xyz, p=2, dim=-1)
             real_spherical_harmonics.rsh(out, xyz_unit)
-            norm_coef = [elem for l in range((max_l+1)//2) for elem in [1.]*(4*l + 1) + [-1.]*(4*l+3)]  # (-1)^L same as (pi-theta) -> (-1)^(L+m) and 'quantum' norm (-1)^m combined
+            norm_coef = [elem for lh in range((max_l+1)//2) for elem in [1.]*(4*lh + 1) + [-1.]*(4*lh+3)]  # (-1)^L same as (pi-theta) -> (-1)^(L+m) and 'quantum' norm (-1)^m combined  # h - halved
             if max_l % 2 == 0:
                 norm_coef.extend([1.]*(2*max_l + 1))
             norm_coef = torch.tensor(norm_coef, device=device).unsqueeze(1)

--- a/se3cnn/SO3.py
+++ b/se3cnn/SO3.py
@@ -11,6 +11,8 @@ import torch
 from se3cnn.util.cache_file import cached_dirpklgz
 from se3cnn.util.default_dtype import torch_default_dtype
 
+from se3cnn import real_spherical_harmonics
+
 
 def rot_z(gamma):
     """
@@ -315,13 +317,29 @@ def spherical_harmonics_xyz(order, xyz, sph_last=False, dtype=None, device=None)
         xyz = torch.tensor(xyz, dtype=torch.float64)
 
     with torch_default_dtype(torch.float64):
-        alpha, beta = xyz_to_angles(xyz)  # two tensors of shape [...]
-        out = spherical_harmonics(order, alpha, beta)  # [m, ...]
+        if device.type == 'cuda' and max(order) <= 6:
+            max_l = max(order)
+            out = xyz.new_empty(((max_l + 1)*(max_l + 1), xyz.size(0)))                                 # [filters, batch_size]
+            xyz_unit = torch.nn.functional.normalize(xyz, p=2, dim=-1)
+            real_spherical_harmonics.rsh(out, xyz_unit)
+            norm_coef = [elem for l in range((max_l+1)//2) for elem in [1.]*(4*l + 1) + [-1.]*(4*l+3)]  # (-1)^L same as (pi-theta) -> (-1)^(L+m) and 'quantum' norm (-1)^m combined
+            if max_l % 2 == 0:
+                norm_coef.extend([1.]*(2*max_l + 1))
+            norm_coef = torch.tensor(norm_coef, device=device).unsqueeze(1)
+            out.mul_(norm_coef)
+            if order != list(range(max_l+1)):
+                keep_rows = torch.zeros(out.size(0), dtype=torch.bool)
+                [keep_rows[(l*l):((l+1)*(l+1))].fill_(True) for l in order]
+                out = out[keep_rows.to(device)]
+        else:
+            alpha, beta = xyz_to_angles(xyz)  # two tensors of shape [...]
+            out = spherical_harmonics(order, alpha, beta)  # [m, ...]
 
-        # fix values when xyz = 0
-        val = xyz.new_tensor([1 / math.sqrt(4 * math.pi)])
-        val = torch.cat([val if l == 0 else xyz.new_zeros(2 * l + 1) for l in order])  # [m]
-        out[:, xyz.norm(2, -1) == 0] = val.view(-1, 1)
+            # fix values when xyz = 0
+            val = xyz.new_tensor([1 / math.sqrt(4 * math.pi)])
+            val = torch.cat([val if l == 0 else xyz.new_zeros(2 * l + 1) for l in order])  # [m]
+            out[:, xyz.norm(2, -1) == 0] = val.view(-1, 1)
+
         if sph_last:
             rank = len(out.shape)
             return out.to(dtype=dtype, device=device).permute(*range(1, rank), 0).contiguous()

--- a/se3cnn/point/kernel.py
+++ b/se3cnn/point/kernel.py
@@ -1,10 +1,8 @@
 # pylint: disable=C, R, arguments-differ, no-member
 import math
-
 import torch
 
 import se3cnn.SO3 as SO3
-import rsh_cuda
 
 
 class Kernel(torch.nn.Module):
@@ -117,16 +115,7 @@ class Kernel(torch.nn.Module):
         radii = r.norm(2, dim=1)  # [batch]
 
         # precompute all needed spherical harmonics
-        if max(self.set_of_l_filters) <= 6:
-            # TODO: fix euler (?) angles + quantum normalization of Ys and singular case
-            Ys = r.new_empty(((1+max(self.set_of_l_filters))**2, r.size(0)))
-            r_tmp = r / radii.unsqueeze(1)
-            r_tmp[torch.isnan(r_tmp)] = 0.
-            rsh_cuda.rsh(Ys, r_tmp)
-        else:
-            Ys = self.sh(self.set_of_l_filters, r)  # [l_filter * m_filter, batch]
-
-        # Ys = self.sh(self.set_of_l_filters, r)  # [l_filter * m_filter, batch]
+        Ys = self.sh(self.set_of_l_filters, r)  # [l_filter * m_filter, batch]
 
         # note: for the normalization we assume that the variance of coefficients[i] is one
         coefficients = self.R(radii)  # [batch, l_out * l_in * mul_out * mul_in * l_filter]

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,11 @@
 # pylint: disable=not-callable, no-member, invalid-name, line-too-long, wildcard-import, unused-wildcard-import, missing-docstring
 from setuptools import setup, find_packages
+from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 
+# TODO: resolve issue with putting rsh_cuda in submodule se3cnn.rsh_cuda
 setup(
     name='se3cnn',
     url='https://github.com/mariogeiger/se3cnn',
-    packages=find_packages(),
     install_requires=[
         'scipy',
         'lie_learn',
@@ -15,4 +16,16 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
+    ext_modules=[
+        CUDAExtension(
+            name='rsh_cuda',
+            sources=['src/real_spherical_harmonics/rsh_bind.cpp',
+                     'src/real_spherical_harmonics/rsh_cuda.cu'],
+            extra_compile_args={'cxx': ['-std=c++14'],
+                                'nvcc': ['-std=c++14']})
+    ],
+    cmdclass={
+      'build_ext': BuildExtension
+    },
+    packages=find_packages(),
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,20 @@
 from setuptools import setup, find_packages
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 
-# TODO: resolve issue with putting rsh_cuda in submodule se3cnn.rsh_cuda
+# python setup.py develop    - if you wont to be able to execute from PyCharm (or similar IDE) - places .so file into se3cnn folder from which real_spherical_harmonics imports
+
+# Or:
+# python setup.py build_ext
+# python setup.py install    - PyCharm won't work, because it can't resolve import, but executable from terminal
+
+ext_modules = [
+    CUDAExtension('se3cnn.real_spherical_harmonics',
+                  sources=['src/real_spherical_harmonics/rsh_bind.cpp',
+                           'src/real_spherical_harmonics/rsh_cuda.cu'],
+                  extra_compile_args={'cxx': ['-std=c++14'],
+                                      'nvcc': ['-std=c++14']})
+]
+
 setup(
     name='se3cnn',
     url='https://github.com/mariogeiger/se3cnn',
@@ -16,16 +29,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    ext_modules=[
-        CUDAExtension(
-            name='rsh_cuda',
-            sources=['src/real_spherical_harmonics/rsh_bind.cpp',
-                     'src/real_spherical_harmonics/rsh_cuda.cu'],
-            extra_compile_args={'cxx': ['-std=c++14'],
-                                'nvcc': ['-std=c++14']})
-    ],
-    cmdclass={
-      'build_ext': BuildExtension
-    },
+    ext_modules=ext_modules,
+    cmdclass={'build_ext': BuildExtension},
     packages=find_packages(),
 )

--- a/src/real_spherical_harmonics/rsh_bind.cpp
+++ b/src/real_spherical_harmonics/rsh_bind.cpp
@@ -1,0 +1,25 @@
+#include <torch/extension.h>
+
+void real_spherical_harmonics_cuda(
+        torch::Tensor output_placeholder,
+        torch::Tensor radii);
+
+// C++ interface
+
+#define CHECK_CUDA(x) AT_ASSERTM(x.type().is_cuda(), #x " must be a CUDA tensor")
+#define CHECK_CONTIGUOUS(x) AT_ASSERTM(x.is_contiguous(), #x " must be contiguous")
+#define CHECK_INPUT(x) CHECK_CUDA(x); CHECK_CONTIGUOUS(x)
+
+void real_spherical_harmonics(
+        torch::Tensor output_placeholder,
+        torch::Tensor radii){
+    CHECK_INPUT(output_placeholder);
+    CHECK_INPUT(radii);
+
+    real_spherical_harmonics_cuda(output_placeholder, radii);
+}
+
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("rsh", &real_spherical_harmonics, "Real Spherical Harmonics (CUDA)");
+}

--- a/src/real_spherical_harmonics/rsh_cuda.cu
+++ b/src/real_spherical_harmonics/rsh_cuda.cu
@@ -193,6 +193,11 @@ __constant__ double (*const fptr[]) (const double, const double, const double) =
 	};
 
 
+/*
+    Preceding const means underlying data stays constant.
+    Trailing const means that pointer to the data remains constant.
+    __restrict__ makes a promise that underlying data can be accessed only with this pointer.
+*/
 __global__ void rsh_cuda_kernel(const double* const __restrict__ radii, double* const __restrict__ Ys, const unsigned int batch_size) {
 	const unsigned int entry_pos = blockDim.x*blockIdx.x + threadIdx.x;     // position of entry in batch
 	if (entry_pos >= batch_size) return;                                    // early terminate if outside the batch - last warp (of threads) can be only partially filled

--- a/src/real_spherical_harmonics/rsh_cuda.cu
+++ b/src/real_spherical_harmonics/rsh_cuda.cu
@@ -1,0 +1,216 @@
+/*
+    Calculates real spherical harmonics up to L=6 (inclusive) from Cartesian coordinates.
+    Coordinate vector is expected to be of unit length.
+*/
+
+#include <torch/extension.h>
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+// 1./sqrt(pi) - on higher precision than actual execution of operation over double can provide
+__device__ constexpr double RSQRT_PI() 		{ return 		0.564189583547756286948079451560772585844050629328998856844;}
+
+/*
+   Idea of the following list of constexpr functions is to compute coefficients once at compile time,
+   and embed them as a direct access constants, same as if they were explicitly written (e.g. 5.5).
+   Strictly speaking constexpr can, but not guarantee calculation of expression at compile time.
+   Here all functions accept no parameters, so probability of fail scenario is extremely low.
+   When in doubt, run:
+        nvcc -ptx rsh_cuda.cu
+   and check if constexpr computed in rsh_cuda.ptx file.
+
+   Coefficients are either for a whole expression (e.g.: RSH_C11), or for monomial of z.
+   Note: power marked for immediate multiplier: ..._z2 * z^2, but also (..._z2 * z^2 + ..._c) * z.
+*/
+__device__ constexpr double RSH_C00() 		{ return 		RSQRT_PI()/2.			  		;}
+
+__device__ constexpr double RSH_C10() 		{ return 		RSQRT_PI()*sqrt(3.)/2.    		;}
+__device__ constexpr double RSH_C11() 		{ return 		RSQRT_PI()*sqrt(3.)/2.    		;}
+
+__device__ constexpr double RSH_C20_c() 	{ return 		RSQRT_PI()*sqrt(5.)/4.    		;}
+__device__ constexpr double RSH_C20_z2() 	{ return 		RSQRT_PI()*sqrt(5.)*3./4.       ;}
+__device__ constexpr double RSH_C21() 		{ return 		RSQRT_PI()*sqrt(15.)/2.   		;}
+__device__ constexpr double RSH_C22() 		{ return 		RSQRT_PI()*sqrt(15.)/4.   		;}
+
+__device__ constexpr double RSH_C30_c() 	{ return 		RSQRT_PI()*sqrt(7.)*3./4.  		;}
+__device__ constexpr double RSH_C30_z2() 	{ return 		RSQRT_PI()*sqrt(7.)*5./4.  		;}
+__device__ constexpr double RSH_C31_c() 	{ return 		RSQRT_PI()*sqrt(42.)/8.   		;}
+__device__ constexpr double RSH_C31_z2() 	{ return 		RSQRT_PI()*sqrt(42.)*5./8. 		;}
+__device__ constexpr double RSH_C32() 		{ return 		RSQRT_PI()*sqrt(105.)/4.  		;}
+__device__ constexpr double RSH_C33() 		{ return 		RSQRT_PI()*sqrt(70.)/8.   		;}
+
+__device__ constexpr double RSH_C40_c()		{ return 		RSQRT_PI()*9./16.          		;}
+__device__ constexpr double RSH_C40_z2() 	{ return 		RSQRT_PI()*90./16.         		;}
+__device__ constexpr double RSH_C40_z4() 	{ return 		RSQRT_PI()*105./16.        		;}
+__device__ constexpr double RSH_C41_c() 	{ return 		RSQRT_PI()*sqrt(10.)*9./8.		;}
+__device__ constexpr double RSH_C41_z2() 	{ return 		RSQRT_PI()*sqrt(10.)*21./8.		;}
+__device__ constexpr double RSH_C42_c() 	{ return 		RSQRT_PI()*sqrt(5.)*3./8.  		;}
+__device__ constexpr double RSH_C42_z2() 	{ return 		RSQRT_PI()*sqrt(5.)*21./8. 		;}
+__device__ constexpr double RSH_C43() 		{ return 		RSQRT_PI()*sqrt(70.)*3./8. 		;}
+__device__ constexpr double RSH_C44() 		{ return 		RSQRT_PI()*sqrt(35.)*3./16.		;}
+
+__device__ constexpr double RSH_C50_c() 	{ return 		RSQRT_PI()*sqrt(11.)*15./16. 	;}
+__device__ constexpr double RSH_C50_z2() 	{ return 		RSQRT_PI()*sqrt(11.)*70./16. 	;}
+__device__ constexpr double RSH_C50_z4() 	{ return 		RSQRT_PI()*sqrt(11.)*63./16. 	;}
+__device__ constexpr double RSH_C51_c() 	{ return 		RSQRT_PI()*sqrt(165.)/16.   	;}
+__device__ constexpr double RSH_C51_z2() 	{ return 		RSQRT_PI()*sqrt(165.)*14./16.	;}
+__device__ constexpr double RSH_C51_z4() 	{ return 		RSQRT_PI()*sqrt(165.)*21./16.	;}
+__device__ constexpr double RSH_C52_c() 	{ return 		RSQRT_PI()*sqrt(1155.)/8.   	;}
+__device__ constexpr double RSH_C52_z2() 	{ return 		RSQRT_PI()*sqrt(1155.)*3./8. 	;}
+__device__ constexpr double RSH_C53_c() 	{ return 		RSQRT_PI()*sqrt(770.)/32.   	;}
+__device__ constexpr double RSH_C53_z2() 	{ return 		RSQRT_PI()*sqrt(770.)*9./32. 	;}
+__device__ constexpr double RSH_C54() 		{ return 		RSQRT_PI()*sqrt(385.)*3./16.  	;}
+__device__ constexpr double RSH_C55() 		{ return 		RSQRT_PI()*sqrt(154.)*3./32. 	;}
+
+__device__ constexpr double RSH_C60_c() 	{ return 		RSQRT_PI()*sqrt(13.)*5./32. 	;}
+__device__ constexpr double RSH_C60_z2() 	{ return 		RSQRT_PI()*sqrt(13.)*105./32. 	;}
+__device__ constexpr double RSH_C60_z4() 	{ return 		RSQRT_PI()*sqrt(13.)*315./32. 	;}
+__device__ constexpr double RSH_C60_z6() 	{ return 		RSQRT_PI()*sqrt(13.)*231./32. 	;}
+__device__ constexpr double RSH_C61_c() 	{ return 		RSQRT_PI()*sqrt(273.)*5./16.  	;}
+__device__ constexpr double RSH_C61_z2() 	{ return 		RSQRT_PI()*sqrt(273.)*30./16.	;}
+__device__ constexpr double RSH_C61_z4() 	{ return 		RSQRT_PI()*sqrt(273.)*33./16.	;}
+__device__ constexpr double RSH_C62_c() 	{ return 		RSQRT_PI()*sqrt(2730.)/64.   	;}
+__device__ constexpr double RSH_C62_z2() 	{ return 		RSQRT_PI()*sqrt(2730.)*18./64. 	;}
+__device__ constexpr double RSH_C62_z4() 	{ return 		RSQRT_PI()*sqrt(2730.)*33./64. 	;}
+__device__ constexpr double RSH_C63_c() 	{ return 		RSQRT_PI()*sqrt(2730.)*3./32.   ;}
+__device__ constexpr double RSH_C63_z2() 	{ return 		RSQRT_PI()*sqrt(2730.)*11./32. 	;}
+__device__ constexpr double RSH_C64_c() 	{ return 		RSQRT_PI()*sqrt(91.)*3./32.  	;}
+__device__ constexpr double RSH_C64_z2() 	{ return 		RSQRT_PI()*sqrt(91.)*33./32.  	;}
+__device__ constexpr double RSH_C65() 		{ return 		RSQRT_PI()*sqrt(2002.)*3./32. 	;}
+__device__ constexpr double RSH_C66() 		{ return 		RSQRT_PI()*sqrt(6006.)/64.  	;}
+
+
+/*
+    Compressed sin^m(theta)*[exp^(-i*m*phi) - exp^(i*m*phi)] and sin^m(theta)*[exp^(-i*m*phi) + exp^(i*m*phi)].
+    These are shared multipliers for multiple L.
+
+    __forceinline__ forces body of the function to be substituted in the place of the call.
+    It proportionally enlarges executable size, but on the other hand saves time otherwise required to resolve function call.
+*/
+__device__ __forceinline__ double f_phi_n6(const double x, const double y) { const double x2 = x*x, y2 = y*y; 					return x * y * (3.*x2 - y2) * (x2 - 3.*y2) * 2. ; }
+__device__ __forceinline__ double f_phi_n5(const double x, const double y) { const double x2 = x*x, y2 = y*y; 					return y * (y2*y2 + 5.*x2 * (x2 - 2.*y2))	    ; }
+__device__ __forceinline__ double f_phi_n4(const double x, const double y) { 													return x * y * (x + y) * (x - y) * 4.		    ; }
+__device__ __forceinline__ double f_phi_n3(const double x, const double y) { 													return y * (3.*x*x - y*y)				        ; }
+__device__ __forceinline__ double f_phi_n2(const double x, const double y) { 													return x * y * 2.							    ; }
+__device__ __forceinline__ double f_phi_n1(const double x, const double y) { 													return y								        ; }
+
+__device__ __forceinline__ double f_phi_p1(const double x, const double y) { 													return x								        ; }
+__device__ __forceinline__ double f_phi_p2(const double x, const double y) { 													return (x + y) * (x - y)				        ; }
+__device__ __forceinline__ double f_phi_p3(const double x, const double y) { 													return x * (x*x - 3.*y*y)				        ; }
+__device__ __forceinline__ double f_phi_p4(const double x, const double y) { const double x2 = x*x, y2 = y*y; 					return x2 * (x2 - 6.*y2) + y2*y2			    ; }
+__device__ __forceinline__ double f_phi_p5(const double x, const double y) { const double x2 = x*x, y2 = y*y; 					return x * (x2*x2 + 5.*y2 * (y2 - 2.*x2))	    ; }
+__device__ __forceinline__ double f_phi_p6(const double x, const double y) { const double x2 = x*x, y2 = y*y, dx2y2 = x2 - y2; 	return dx2y2 * (dx2y2*dx2y2 - 12.*x2*y2)        ; }
+
+
+/*
+    Functions for specific (L, m). Product of common multiplier from m and polynomial in z.
+    In principle, said polynomials can be constructed with another inline proxy function, but it seems to be more on the obfuscation side.
+    Polynomials are the same both for -m and +m, but we can't really use that here, because each function below should be "baked".
+
+*/
+
+__device__ double sh00 (const double x, const double y, const double z) { return RSH_C00(); }
+
+__device__ double sh1n1(const double x, const double y, const double z) { return f_phi_n1(x, y) * RSH_C11(); }
+__device__ double sh10 (const double x, const double y, const double z) { return 				  RSH_C10() * z; }
+__device__ double sh1p1(const double x, const double y, const double z) { return f_phi_p1(x, y) * RSH_C11(); }
+
+__device__ double sh2n2(const double x, const double y, const double z) { return f_phi_n2(x, y) * RSH_C22(); }
+__device__ double sh2n1(const double x, const double y, const double z) { return f_phi_n1(x, y) * RSH_C21() * z; }
+__device__ double sh20 (const double x, const double y, const double z) { return 				  RSH_C20_z2() * z * z - RSH_C20_c(); }
+__device__ double sh2p1(const double x, const double y, const double z) { return f_phi_p1(x, y) * RSH_C21() * z; }
+__device__ double sh2p2(const double x, const double y, const double z) { return f_phi_p2(x, y) * RSH_C22(); }
+
+__device__ double sh3n3(const double x, const double y, const double z) { return f_phi_n3(x, y) * RSH_C33(); }
+__device__ double sh3n2(const double x, const double y, const double z) { return f_phi_n2(x, y) * RSH_C32() * z; }
+__device__ double sh3n1(const double x, const double y, const double z) { return f_phi_n1(x, y) * (RSH_C31_z2() * z * z - RSH_C31_c()); }
+__device__ double sh30 (const double x, const double y, const double z) { return 				  (RSH_C30_z2() * z * z - RSH_C30_c()) * z; }
+__device__ double sh3p1(const double x, const double y, const double z) { return f_phi_p1(x, y) * (RSH_C31_z2() * z * z - RSH_C31_c()); }
+__device__ double sh3p2(const double x, const double y, const double z) { return f_phi_p2(x, y) * RSH_C32() * z; }
+__device__ double sh3p3(const double x, const double y, const double z) { return f_phi_p3(x, y) * RSH_C33(); }
+
+__device__ double sh4n4(const double x, const double y, const double z) { return f_phi_n4(x, y) * RSH_C44(); }
+__device__ double sh4n3(const double x, const double y, const double z) { return f_phi_n3(x, y) * RSH_C43() * z; }
+__device__ double sh4n2(const double x, const double y, const double z) { return f_phi_n2(x, y) * (RSH_C42_z2() * z * z - RSH_C42_c()); }
+__device__ double sh4n1(const double x, const double y, const double z) { return f_phi_n1(x, y) * (RSH_C41_z2() * z * z - RSH_C41_c()) * z; }
+__device__ double sh40 (const double x, const double y, const double z) { const double z2 = z * z;
+																		  return 				  (RSH_C40_z4() * z2 * z2 - RSH_C40_z2() * z2 + RSH_C40_c()); }
+__device__ double sh4p1(const double x, const double y, const double z) { return f_phi_p1(x, y) * (RSH_C41_z2() * z * z - RSH_C41_c()) * z; }
+__device__ double sh4p2(const double x, const double y, const double z) { return f_phi_p2(x, y) * (RSH_C42_z2() * z * z - RSH_C42_c()); }
+__device__ double sh4p3(const double x, const double y, const double z) { return f_phi_p3(x, y) * RSH_C43() * z; }
+__device__ double sh4p4(const double x, const double y, const double z) { return f_phi_p4(x, y) * RSH_C44(); }
+
+__device__ double sh5n5(const double x, const double y, const double z) { return f_phi_n5(x, y) * RSH_C55(); }
+__device__ double sh5n4(const double x, const double y, const double z) { return f_phi_n4(x, y) * RSH_C54() * z; }
+__device__ double sh5n3(const double x, const double y, const double z) { return f_phi_n3(x, y) * (RSH_C53_z2() * z * z - RSH_C53_c()); }
+__device__ double sh5n2(const double x, const double y, const double z) { return f_phi_n2(x, y) * (RSH_C52_z2() * z * z - RSH_C52_c()) * z; }
+__device__ double sh5n1(const double x, const double y, const double z) { const double z2 = z*z;
+																		  return f_phi_n1(x, y) * (RSH_C51_z4() * z2 * z2 - RSH_C51_z2() * z2 + RSH_C51_c()); }
+__device__ double sh50 (const double x, const double y, const double z) { const double z2 = z*z;
+																		  return 				  (RSH_C50_z4() * z2 * z2 - RSH_C50_z2() * z2 + RSH_C50_c()) * z; }
+__device__ double sh5p1(const double x, const double y, const double z) { const double z2 = z*z;
+																		  return f_phi_p1(x, y) * (RSH_C51_z4() * z2 * z2 - RSH_C51_z2() * z2 + RSH_C51_c()); }
+__device__ double sh5p2(const double x, const double y, const double z) { return f_phi_p2(x, y) * (RSH_C52_z2() * z * z - RSH_C52_c()) * z; }
+__device__ double sh5p3(const double x, const double y, const double z) { return f_phi_p3(x, y) * (RSH_C53_z2() * z * z - RSH_C53_c()); }
+__device__ double sh5p4(const double x, const double y, const double z) { return f_phi_p4(x, y) * RSH_C54() * z; }
+__device__ double sh5p5(const double x, const double y, const double z) { return f_phi_p5(x, y) * RSH_C55(); }
+
+__device__ double sh6n6(const double x, const double y, const double z) { return f_phi_n6(x, y) * RSH_C66(); }
+__device__ double sh6n5(const double x, const double y, const double z) { return f_phi_n5(x, y) * RSH_C65() * z; }
+__device__ double sh6n4(const double x, const double y, const double z) { return f_phi_n4(x, y) * (RSH_C64_z2() * z * z - RSH_C64_c()); }
+__device__ double sh6n3(const double x, const double y, const double z) { return f_phi_n3(x, y) * (RSH_C63_z2() * z * z - RSH_C63_c()) * z; }
+__device__ double sh6n2(const double x, const double y, const double z) { const double z2 = z*z;
+                                                                          return f_phi_n2(x, y) * (RSH_C62_z4() * z2 * z2 - RSH_C62_z2() * z2 + RSH_C62_c()); }
+__device__ double sh6n1(const double x, const double y, const double z) { const double z2 = z*z;
+                                                                          return f_phi_n1(x, y) * (RSH_C61_z4() * z2 * z2 - RSH_C61_z2() * z2 + RSH_C61_c()) * z; }
+__device__ double sh60 (const double x, const double y, const double z) { const double z2 = z*z;
+                                                                          return                  RSH_C60_z6() * z2 * z2 * z2 - RSH_C60_z4() * z2 * z2 + RSH_C60_z2() * z2 - RSH_C60_c(); }
+__device__ double sh6p1(const double x, const double y, const double z) { const double z2 = z*z;
+                                                                          return f_phi_p1(x, y) * (RSH_C61_z4() * z2 * z2 - RSH_C61_z2() * z2 + RSH_C61_c()) * z; }
+__device__ double sh6p2(const double x, const double y, const double z) { const double z2 = z*z;
+                                                                          return f_phi_p2(x, y) * (RSH_C62_z4() * z2 * z2 - RSH_C62_z2() * z2 + RSH_C62_c()); }
+__device__ double sh6p3(const double x, const double y, const double z) { return f_phi_p3(x, y) * (RSH_C63_z2() * z * z - RSH_C63_c()) * z; }
+__device__ double sh6p4(const double x, const double y, const double z) { return f_phi_p4(x, y) * (RSH_C64_z2() * z * z - RSH_C64_c()); }
+__device__ double sh6p5(const double x, const double y, const double z) { return f_phi_p5(x, y) * RSH_C65() * z; }
+__device__ double sh6p6(const double x, const double y, const double z) { return f_phi_p6(x, y) * RSH_C66(); }
+
+
+// array of pointers to functions stored to "constant memory" (__constant__) in GPU.
+__constant__ double (*const fptr[]) (const double, const double, const double) = {
+		                                          sh00, 											//                         0
+		                                   sh1n1, sh10,  sh1p1, 									//                     1,  2,  3
+		                            sh2n2, sh2n1, sh20,  sh2p1, sh2p2,								//                  4, 5,  6,  7,  8
+		                     sh3n3, sh3n2, sh3n1, sh30,  sh3p1, sh3p2, sh3p3,					    //              9, 10, 11, 12, 13, 14, 15
+		              sh4n4, sh4n3, sh4n2, sh4n1, sh40,  sh4p1, sh4p2, sh4p3, sh4p4,				//         16, 17, 18, 19, 20, 21, 22, 23, 24
+		       sh5n5, sh5n4, sh5n3, sh5n2, sh5n1, sh50,  sh5p1, sh5p2, sh5p3, sh5p4, sh5p5,		    //     25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35
+		sh6n6, sh6n5, sh6n4, sh6n3, sh6n2, sh6n1, sh60,  sh6p1, sh6p2, sh6p3, sh6p4, sh6p5, sh6p6   // 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48
+	};
+
+
+__global__ void rsh_cuda_kernel(const double* const __restrict__ radii, double* const __restrict__ Ys, const unsigned int batch_size) {
+	const unsigned int entry_pos = blockDim.x*blockIdx.x + threadIdx.x;     // position of entry in batch
+	if (entry_pos >= batch_size) return;                                    // early terminate if outside the batch - last warp (of threads) can be only partially filled
+
+	const double x = radii[3*entry_pos];                                    // "strided memory access" is generally not nice and severely drops throughput
+	const double y = radii[3*entry_pos+1];                                  // padding to 4 and packing in double4 (single read transaction) showed no noticeable improvement (is scale to0 small measure?)
+	const double z = radii[3*entry_pos+2];                                  // 100+ GB/s of throughput would be great, but even 3 GB/s does not make a bottleneck
+
+    Ys[blockIdx.y*batch_size + entry_pos] = fptr[blockIdx.y](x, y, z);      // select function, apply and store result to the "global memory"
+}
+
+
+void real_spherical_harmonics_cuda(
+        torch::Tensor output_placeholder,
+        torch::Tensor radii) {
+    const unsigned int filters = output_placeholder.size(0);
+    const unsigned int batch_size = radii.size(0);
+
+    double* const Ys_ptr = (double*) output_placeholder.data_ptr();
+    const double* const radii_ptr = (const double*) radii.data_ptr();
+
+    const unsigned int threads_per_block = 32;                              // warp size in contemporary GPUs is 32 threads, this variable should be a multiple of warp size
+    dim3 numBlocks((batch_size + threads_per_block - 1)/threads_per_block, filters, 1);
+
+    rsh_cuda_kernel<<<numBlocks, threads_per_block>>>(radii_ptr, Ys_ptr, batch_size);
+}

--- a/tests/SO3_tests.py
+++ b/tests/SO3_tests.py
@@ -9,6 +9,18 @@ from se3cnn.SO3 import *
 
 class Tests(unittest.TestCase):
 
+    def test_sh_cuda(self):
+        if torch.cuda.is_available():
+            with torch_default_dtype(torch.float64):
+                for l in range(6 + 1):
+                    x = torch.randn(10, 3)
+                    x_cuda = x.cuda()
+                    Y1 = spherical_harmonics_xyz(l, x)
+                    Y2 = spherical_harmonics_xyz(l, x_cuda).cpu()
+                    self.assertLess((Y1 - Y2).abs().max(), 1e-7)
+        else:
+            print("Cuda is not available! test_sh_cuda skipped!")
+
     def test_sh_partiy(self):
         """
         (-1)^l Y(x) = Y(-x)

--- a/tests/SO3_tests.py
+++ b/tests/SO3_tests.py
@@ -9,7 +9,7 @@ from se3cnn.SO3 import *
 
 class Tests(unittest.TestCase):
 
-    def test_sh_cuda(self):
+    def test_sh_cuda_single(self):
         if torch.cuda.is_available():
             with torch_default_dtype(torch.float64):
                 for l in range(6 + 1):
@@ -19,9 +19,36 @@ class Tests(unittest.TestCase):
                     Y2 = spherical_harmonics_xyz(l, x_cuda).cpu()
                     self.assertLess((Y1 - Y2).abs().max(), 1e-7)
         else:
-            print("Cuda is not available! test_sh_cuda skipped!")
+            print("Cuda is not available! test_sh_cuda_single skipped!")
 
-    def test_sh_partiy(self):
+
+    def test_sh_cuda_ordered_full(self):
+        if torch.cuda.is_available():
+            with torch_default_dtype(torch.float64):
+                l = [0, 1, 2, 3, 4, 5, 6]
+                x = torch.randn(10, 3)
+                x_cuda = x.cuda()
+                Y1 = spherical_harmonics_xyz(l, x)
+                Y2 = spherical_harmonics_xyz(l, x_cuda).cpu()
+                self.assertLess((Y1 - Y2).abs().max(), 1e-7)
+        else:
+            print("Cuda is not available! test_sh_cuda_ordered_full skipped!")
+
+
+    def test_sh_cuda_ordered_partial(self):
+        if torch.cuda.is_available():
+            with torch_default_dtype(torch.float64):
+                l = [0, 2, 5]
+                x = torch.randn(10, 3)
+                x_cuda = x.cuda()
+                Y1 = spherical_harmonics_xyz(l, x)
+                Y2 = spherical_harmonics_xyz(l, x_cuda).cpu()
+                self.assertLess((Y1 - Y2).abs().max(), 1e-7)
+        else:
+            print("Cuda is not available! test_sh_cuda_ordered_partial skipped!")
+
+
+    def test_sh_parity(self):
         """
         (-1)^l Y(x) = Y(-x)
         """


### PR DESCRIPTION
Added custom extension that calculates real spherical harmonics up to L=6, using direct formulas in Cartesian coordinates.

It is embedded into the call of **spherical_harmonics_xyz** and given priority when applicable. It should match prior behavior except for the following: 
1. Input is expected in form [batch X xyz]. Cases when batch is equal to 1 and missing as a dimension result in improperly sized output. I think it should be treated earlier in the pipeline, but if there is a chance for a function to be called independently, unsqueeze or assert can be added.
2. Order is expected as an integer or ordered (!) list of integers. If for some reason there is a need for unordered lists, mask over byteTensor can be replaced with slicing over longTensor.

Main purpose is to speed up common routines. 
Using network from structure.py and Materials Project dataset as a timing benchmark, time spent by algorithm cumulatively on spherical_harmonics_xyz.
Before: ~1 hour 12 minutes
After:    ~1 minute 30 seconds (from which 3.7 seconds rsh call itself)