### PR TITLE
setup.py

### DIFF
--- a/se3cnn/SO3.py
+++ b/se3cnn/SO3.py
@@ -11,7 +11,8 @@ import torch
 from se3cnn.util.cache_file import cached_dirpklgz
 from se3cnn.util.default_dtype import torch_default_dtype
 
-from se3cnn import real_spherical_harmonics
+if torch.cuda.is_available():
+    from se3cnn import real_spherical_harmonics
 
 
 def rot_z(gamma):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,10 @@ from torch.utils.cpp_extension import BuildExtension, CUDAExtension, CUDA_HOME
 # python setup.py build_ext
 # python setup.py install    - PyCharm won't work, because it can't resolve import, but executable from terminal
 
-if torch.cuda.is_available() and CUDA_HOME is not None:
+if not torch.cuda.is_available():
+    ext_modules = None
+    print("GPU is not available. Skip building CUDA extensions.")
+elif torch.cuda.is_available() and CUDA_HOME is not None:
     ext_modules = [
         CUDAExtension('se3cnn.real_spherical_harmonics',
                       sources=['src/real_spherical_harmonics/rsh_bind.cpp',
@@ -18,12 +21,8 @@ if torch.cuda.is_available() and CUDA_HOME is not None:
                                           'nvcc': ['-std=c++14']})
     ]
 else:
-    ext_modules = None
-    print("Skipping building of real spherical harmonics CUDA extension.")
-    if not torch.cuda.is_available():
-        print("PyTorch is unable to find GPU")
-    if CUDA_HOME is None:
-        print("CUDA_HOME is undefined. Is there nvcc compiler (cuda toolkit)?")
+    # GPU is available, but CUDA_HOME is None
+    raise AssertionError("CUDA_HOME is undefined. Make sure nvcc compiler is available (cuda toolkit installed?)")
 
 setup(
     name='se3cnn',


### PR DESCRIPTION
Skip building (and import) of cuda extensions if no gpu is available. 
Insist on getting nvcc compiler if it is missing, while gpu is available. 